### PR TITLE
add uiState - separate from stores

### DIFF
--- a/StateFromStoresMixin.js
+++ b/StateFromStoresMixin.js
@@ -1,7 +1,7 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
-*/
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Tobias Koppers @sokra
+ */
 var React = require("react");
 var ItemsStoreLease = require("./ItemsStoreLease");
 var ItemsStoreFetcher = require("./ItemsStoreFetcher");
@@ -28,7 +28,7 @@ function makeStores(stores, addDepenency) {
 			isItemUpToDate: function(id) {
 				addDepenency(stores[key], id);
 				return stores[key].isItemUpToDate(id);
-			},
+			}
 		};
 		return obj;
 	}, {});
@@ -38,7 +38,7 @@ module.exports = {
 	statics: {
 		chargeStores: function(stores, params, callback) {
 			ItemsStoreFetcher.fetch(function(addDepenency) {
-				this.getState(makeStores(stores, addDepenency), params);
+				this.getStoreState(makeStores(stores, addDepenency), params);
 			}.bind(this), callback);
 		}
 	},
@@ -49,7 +49,9 @@ module.exports = {
 		var This = this.constructor;
 		if(!this.itemsStoreLease) this.itemsStoreLease = new ItemsStoreLease();
 		return this.itemsStoreLease.capture(function(addDepenency) {
-			return This.getState(makeStores(this.context.stores, addDepenency), this.getParams && this.getParams());
+			return this.mergeStates(
+				This.getStoreState(makeStores(this.context.stores, addDepenency), this.getParams && this.getParams())
+			);
 		}.bind(this), this.StateFromStoresMixin_onUpdate);
 	},
 	StateFromStoresMixin_onUpdate: function() {
@@ -63,14 +65,37 @@ module.exports = {
 		if(!this.isMounted()) return;
 		var This = this.constructor;
 		this.setState(this.itemsStoreLease.capture(function(addDepenency) {
-			return This.getState(makeStores(this.context.stores, addDepenency), this.getParams && this.getParams());
+			return this.mergeStates(
+				This.getStoreState(makeStores(this.context.stores, addDepenency), this.getParams && this.getParams())
+			);
 		}.bind(this), this.StateFromStoresMixin_onUpdate));
 	},
+
+	/*
+	*  I want UI state to exist outside of stores.
+	*  TODO: _.merge is insufficient if state is intermingled. stale store data accumulate.
+	*  TODO: if an item is deleted on the server, then new storeState is created
+	*  TODO: that item will still exist in this.state
+	*
+	*  TODO: I think
+	* */
+	mergeStates: function(storeState) {
+		var This = this.constructor;
+		var uiState = !this.isMounted() ? This.getUiState() : this.state;
+
+		//		return _.merge(uiState, storeState);
+
+		// TODO: this works if uiState and storeState don't have any collisions
+		return Object.assign({}, uiState, storeState);
+	},
+
 	componentWillReceiveProps: function(newProps, newContext) {
 		if(!newContext) return;
 		var This = this.constructor;
 		this.setState(this.itemsStoreLease.capture(function(addDepenency) {
-			return This.getState(makeStores(newContext.stores, addDepenency), newContext.getCurrentParams && newContext.getCurrentParams());
+			return this.mergeStates(
+				This.getStoreState(makeStores(newContext.stores, addDepenency), newContext.getCurrentParams && newContext.getCurrentParams())
+			);
 		}.bind(this), this.StateFromStoresMixin_onUpdate));
 	},
 	contextTypes: {


### PR DESCRIPTION
Hi Tobias, I don't expect you to merge this in without some discussion and a few iterations, and I'm not sure if this is even the answer but I would like your thoughts. I'm bootstrapping a front-end using webpack/react-starter, which I think is excellent and I've spent the past few days trying to understand it.

I have worked with React on some large projects about a year ago and hadn't used a Flux library before. A colleague of mine wrote react-cursor, inspired by Om cursors to manage top-level state and have deeply nested but stateless React components.

We think stores are a good idea for managing any data that comes from the server, but UI changes - button clicks,  opening menus, etc. should be separate. The idea is that UI is managed through cursors while store updates use Flux.

The problem I ran into in doing this is that when stores update, brand new state is created and my UI state is blown away. I suppose another option would be to have a nested component where UI state lives but this seems clunky.
