### PR TITLE
add query to fix #12, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A helper class which leases multiple items from multiple stores. It captures dep
 
 ### createContainer
 
-A wrapper for a React component. It expects a static `getProps` method from the component that calculate `props` from stores (and params when using react-router). The wrapper container handles listening to changes and charging of stores.
+A wrapper for a React component. It expects a static `getProps` method from the component that calculates `props` from stores (plus `params` and `query` when using react-router). The wrapper container handles listening to changes and charging of stores.
 
 The usable API inside the `getProps` method is very simple and synchronous. See API > createContainer.
 
@@ -243,9 +243,9 @@ It's expected from the component to provide a static `getProps` function.
 
 The context of the component must contain a key `stores` which is an object containing all stores (i. e. `{Messages: [ItemsStore], Users: [ItemsStore]}`).
 
-#### static `getProps(stores, params)`
+#### static `getProps(stores, params, query)`
 
-This function should create the component `props` from `stores` and `params` and return it.
+This function should create the component `props` from `stores`, `params`, and `query` and return it.
 
 `stores` is an object containing a dependency-tracking version of each store i. e.
 ```
@@ -265,7 +265,7 @@ This function should create the component `props` from `stores` and `params` and
 }
 ```
 
-`params` is the params object from `react-router` (if used)
+`params` and `query` are objects from `react-router` (if used)
 
 Example for a `getProps` method:
 
@@ -291,13 +291,15 @@ statics: {
 
 **wrapper methods**
 
-#### static `chargeStores(stores, params, callback)`
+#### static `chargeStores(stores, params, query, callback)`
 
 Prepares stores with an `ItemsStoreFetcher`.
 
 `stores` The object of `ItemsStores`, like the `stores` key in the context.
 
 `params` params object from `react-router`.
+
+`query` query object from `react-router`.
 
 
 

--- a/createContainer.js
+++ b/createContainer.js
@@ -41,9 +41,12 @@ module.exports = function createContainer(Component) {
 	return React.createClass({
 		displayName: componentName + "Container",
 		statics: {
-			chargeStores: function(stores, params, callback) {
+			chargeStores: function(stores, params, query, callback) {
+				if (typeof query === 'function') {
+					callback = query;
+				}
 				ItemsStoreFetcher.fetch(function(addDependency) {
-					Component.getProps(makeStores(stores, addDependency), params);
+					Component.getProps(makeStores(stores, addDependency), params, query);
 				}.bind(this), callback);
 			}
 		},
@@ -52,8 +55,9 @@ module.exports = function createContainer(Component) {
 			var stores = this.context.stores;
 			var router = this.context.router;
 			var params = router && router.getCurrentParams && router.getCurrentParams();
+			var query = router && router.getCurrentQuery && router.getCurrentQuery();
 			return this.lease.capture(function(addDependency) {
-				return Component.getProps(makeStores(stores, addDependency), params);
+				return Component.getProps(makeStores(stores, addDependency), params, query);
 			}, this._onUpdate);
 		},
 		_onUpdate: function() {
@@ -71,8 +75,9 @@ module.exports = function createContainer(Component) {
 			var stores = this.context.stores;
 			var router = this.context.router;
 			var params = router && router.getCurrentParams && router.getCurrentParams();
+			var query = router && router.getCurrentQuery && router.getCurrentQuery();
 			this.setState(this.lease.capture(function(addDependency) {
-				return Component.getProps(makeStores(stores, addDependency), params);
+				return Component.getProps(makeStores(stores, addDependency), params, query);
 			}, this._onUpdate));
 		},
 		componentWillReceiveProps: function(newProps, newContext) {
@@ -81,8 +86,9 @@ module.exports = function createContainer(Component) {
 			var stores = newContext.stores;
 			var router = newContext.router;
 			var params = router && router.getCurrentParams && router.getCurrentParams();
+			var query = router && router.getCurrentQuery && router.getCurrentQuery();
 			this.setState(this.lease.capture(function(addDependency) {
-				return Component.getProps(makeStores(stores, addDependency), params);
+				return Component.getProps(makeStores(stores, addDependency), params, query);
 			}, this._onUpdate));
 		},
 		componentWillUnmount: function() {


### PR DESCRIPTION
This PR let's us pass react-router's `query` object into our `static getProps` and `chargeStores` methods.

It does not break backwards compatibility with the `chargeStores` api, which expects a callback as its third or fourth argument.
